### PR TITLE
Fix compilation (ForceDirectories instead of ForceDirectory)

### DIFF
--- a/tools/common/crossfiles.pas
+++ b/tools/common/crossfiles.pas
@@ -513,7 +513,7 @@ var
   A, B: string;
 begin
   try
-    ForceDirectory(IncludeTrailingPathDelimiter(FLocation));
+    ForceDirectories(IncludeTrailingPathDelimiter(FLocation));
     Path := ExtractFilePath(FFileName);
     FileName := ExtractFileName(FFileName);
     Folder := StrFirstOf(FileName, '.');


### PR DESCRIPTION
The function ForceDirectory, used in crossfiles.pas, does not exist. This means that trying to compile baredsgn.lpk with the latest FPC 3.0.2 and Lazarus trunk fails.

I'm guessing that you wanted this: http://www.freepascal.org/docs-html/rtl/sysutils/forcedirectories.html :)