### PR TITLE
cast nil to TItem generic type

### DIFF
--- a/source/bare.types.pas
+++ b/source/bare.types.pas
@@ -884,7 +884,7 @@ procedure TObjectList<TItem>.DeleteItem(var Item: TItem);
 begin
   if FOwnsObjects then
     Item.Free;
-  Item := nil;
+  Item := TItem(nil);
 end;
 
 function TObjectList<TItem>.RequiresDelete: Boolean;


### PR DESCRIPTION
Free Pascal 3.2.0 on Windows 10 64 bit requires you to cast this nil, otherwise you get:

`bare.types.pas(887,11) Error: (4001) Incompatible types: got "Pointer" expected "$gendef257"`